### PR TITLE
Add 'Auditors' Line to Commit Messages

### DIFF
--- a/lib/gollum/app.rb
+++ b/lib/gollum/app.rb
@@ -370,7 +370,7 @@ module Precious
       @versions = @wiki.latest_changes({:max_count => max_count})
       mustache :latest_changes
     end
-    
+
     post '/compare/*' do
       @file     = params[:splat].first
       @versions = params[:versions] || []
@@ -525,6 +525,12 @@ module Precious
     # author details are sourced from the session, to be populated by rack middleware ahead of us
     def commit_message
       msg               = (params[:message].nil? or params[:message].empty?) ? "[no message]" : params[:message]
+
+      unless (params[:auditor].nil? or params[:auditor].empty?)
+        auditor = params[:auditor]
+        msg += "\n\nAuditors: #{auditor}"
+      end
+
       commit_message    = { :message => msg }
       author_parameters = session['gollum.author']
       commit_message.merge! author_parameters unless author_parameters.nil?

--- a/lib/gollum/templates/editor.mustache
+++ b/lib/gollum/templates/editor.mustache
@@ -126,6 +126,8 @@
       {{#is_edit_page}}
       <input type="text" name="message" id="gollum-editor-message-field" value="Updated {{page_name}} ({{format}})">
       {{/is_edit_page}}
+      <label for="auditor" class="jaws">Auditors(s)</label>
+      <input type="text" name="auditor" id="gollum-editor-auditor-field" value="" placeholder="auditor(s)">
     </div>
 
     <span class="jaws"><br></span>


### PR DESCRIPTION
Collect reviewers/auditors on edit page and add Auditors: line to commit messages.